### PR TITLE
Configure pid file location explicitly

### DIFF
--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -2,6 +2,7 @@
 nodaemon = {{ supervisor_nodaemon }}
 childlogdir = {{ supervisor_log_dir }}
 user = {{ supervisor_user }}
+pidfile = /var/run/supervisord.pid
 
 {% if supervisor_unix_http_server_enable %}
 [unix_http_server]


### PR DESCRIPTION
Both the Red Hat and Debian start scripts assume that the pid file is
in /var/run/supervisord.pid, but according to the
documentation (http://supervisord.org/configuration.html), the default
value is `$CWD/supervisord.pid`, and apparently we're starting
supervisord in the root directory.

This means that `/etc/init.d/supervisord restart` looks for the pid file
in the wrong location, and wrongly concludes that supervisord is
already stopped.  Then it starts a new supervisord process, which
can't open /var/run/supervisor.sock since it's locked by the still
running process, and exits with the confusing message:

    Error: Another program is already listening on a port that one of
    our HTTP servers is configured to use.  Shut this program down
    first before starting supervisord.
    For help, use /usr/local/bin/supervisord -h

This seems to work properly once we have the right pid file location
configured.